### PR TITLE
docs: add GitHub issue links to task table

### DIFF
--- a/docs/task_table.md
+++ b/docs/task_table.md
@@ -17,47 +17,47 @@
 
 | Task ID | Phase | Title | Plan Link | Issue | Status |
 | --- | --- | --- | --- | --- | --- |
-| F0-01 | 0 | 対象地点/期間/出力フォーマットの合意 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | TBD | Not Started |
-| F0-02 | 0 | Google カレンダーのイベント設計確定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | TBD | Not Started |
-| F0-03 | 0 | 天文潮の取得方式を決定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | TBD | Not Started |
-| F0-04 | 0 | タイドグラフ画像の表現方針（後続検討） | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | TBD | Not Started |
-| F0-05 | 0 | 開発環境手順（uv）をドキュメント化 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | TBD | Not Started |
-| F0-06 | 0 | 配布/セットアップ手順の草案化 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | TBD | Not Started |
-| F0-07 | 0 | 更新ウィンドウの範囲を決定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | TBD | Not Started |
-| F0-08 | 0 | レイヤードアーキテクチャの詳細設計 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | TBD | Not Started |
+| F0-01 | 0 | 対象地点/期間/出力フォーマットの合意 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#4](https://github.com/nakagawah13/fishing-forecast-gcal/issues/4) | Not Started |
+| F0-02 | 0 | Google カレンダーのイベント設計確定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#5](https://github.com/nakagawah13/fishing-forecast-gcal/issues/5) | Not Started |
+| F0-03 | 0 | 天文潮の取得方式を決定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#6](https://github.com/nakagawah13/fishing-forecast-gcal/issues/6) | Not Started |
+| F0-04 | 0 | タイドグラフ画像の表現方針（後続検討） | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#7](https://github.com/nakagawah13/fishing-forecast-gcal/issues/7) | Not Started |
+| F0-05 | 0 | 開発環境手順（uv）をドキュメント化 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#8](https://github.com/nakagawah13/fishing-forecast-gcal/issues/8) | Not Started |
+| F0-06 | 0 | 配布/セットアップ手順の草案化 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#9](https://github.com/nakagawah13/fishing-forecast-gcal/issues/9) | Not Started |
+| F0-07 | 0 | 更新ウィンドウの範囲を決定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#10](https://github.com/nakagawah13/fishing-forecast-gcal/issues/10) | Not Started |
+| F0-08 | 0 | レイヤードアーキテクチャの詳細設計 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#11](https://github.com/nakagawah13/fishing-forecast-gcal/issues/11) | Not Started |
 
 ## フェーズ 1（MVP）
 
 | Task ID | Phase | Title | Plan Link | Issue | Status |
 | --- | --- | --- | --- | --- | --- |
-| T-001 | 1.1 | ドメインモデル定義 | [implementation_plan.md](implementation_plan.md#t-001-ドメインモデル定義) | TBD | Not Started |
-| T-002 | 1.1 | リポジトリインターフェース定義 | [implementation_plan.md](implementation_plan.md#t-002-リポジトリインターフェース定義) | TBD | Not Started |
-| T-003 | 1.1 | 潮汐計算サービス | [implementation_plan.md](implementation_plan.md#t-003-潮汐計算サービス) | TBD | Not Started |
-| T-004 | 1.1 | 潮回り判定サービス | [implementation_plan.md](implementation_plan.md#t-004-潮回り判定サービス) | TBD | Not Started |
-| T-005 | 1.1 | 時合い帯特定サービス | [implementation_plan.md](implementation_plan.md#t-005-時合い帯特定サービス) | TBD | Not Started |
-| T-006 | 1.2 | 潮汐計算ライブラリアダプター | [implementation_plan.md](implementation_plan.md#t-006-潮汐計算ライブラリアダプター) | TBD | Not Started |
-| T-007 | 1.2 | TideDataRepository 実装 | [implementation_plan.md](implementation_plan.md#t-007-tidedatarepository-実装) | TBD | Not Started |
-| T-008 | 1.2 | Google Calendar API クライアント | [implementation_plan.md](implementation_plan.md#t-008-google-calendar-api-クライアント) | TBD | Not Started |
-| T-009 | 1.2 | CalendarRepository 実装 | [implementation_plan.md](implementation_plan.md#t-009-calendarrepository-実装) | TBD | Not Started |
-| T-010 | 1.3 | SyncTideUseCase 実装 | [implementation_plan.md](implementation_plan.md#t-010-synctideusecase-実装) | TBD | Not Started |
-| T-011 | 1.4 | 設定ファイルローダー | [implementation_plan.md](implementation_plan.md#t-011-設定ファイルローダー) | TBD | Not Started |
-| T-012 | 1.4 | CLI エントリーポイント | [implementation_plan.md](implementation_plan.md#t-012-cliエントリーポイント) | TBD | Not Started |
-| T-013 | 1.5 | E2E テスト | [implementation_plan.md](implementation_plan.md#t-013-e2eテスト) | TBD | Not Started |
+| T-001 | 1.1 | ドメインモデル定義 | [implementation_plan.md](implementation_plan.md#t-001-ドメインモデル定義) | [#12](https://github.com/nakagawah13/fishing-forecast-gcal/issues/12) | Not Started |
+| T-002 | 1.1 | リポジトリインターフェース定義 | [implementation_plan.md](implementation_plan.md#t-002-リポジトリインターフェース定義) | [#13](https://github.com/nakagawah13/fishing-forecast-gcal/issues/13) | Not Started |
+| T-003 | 1.1 | 潮汐計算サービス | [implementation_plan.md](implementation_plan.md#t-003-潮汐計算サービス) | [#14](https://github.com/nakagawah13/fishing-forecast-gcal/issues/14) | Not Started |
+| T-004 | 1.1 | 潮回り判定サービス | [implementation_plan.md](implementation_plan.md#t-004-潮回り判定サービス) | [#15](https://github.com/nakagawah13/fishing-forecast-gcal/issues/15) | Not Started |
+| T-005 | 1.1 | 時合い帯特定サービス | [implementation_plan.md](implementation_plan.md#t-005-時合い帯特定サービス) | [#16](https://github.com/nakagawah13/fishing-forecast-gcal/issues/16) | Not Started |
+| T-006 | 1.2 | 潮汐計算ライブラリアダプター | [implementation_plan.md](implementation_plan.md#t-006-潮汐計算ライブラリアダプター) | [#17](https://github.com/nakagawah13/fishing-forecast-gcal/issues/17) | Not Started |
+| T-007 | 1.2 | TideDataRepository 実装 | [implementation_plan.md](implementation_plan.md#t-007-tidedatarepository-実装) | [#18](https://github.com/nakagawah13/fishing-forecast-gcal/issues/18) | Not Started |
+| T-008 | 1.2 | Google Calendar API クライアント | [implementation_plan.md](implementation_plan.md#t-008-google-calendar-api-クライアント) | [#19](https://github.com/nakagawah13/fishing-forecast-gcal/issues/19) | Not Started |
+| T-009 | 1.2 | CalendarRepository 実装 | [implementation_plan.md](implementation_plan.md#t-009-calendarrepository-実装) | [#20](https://github.com/nakagawah13/fishing-forecast-gcal/issues/20) | Not Started |
+| T-010 | 1.3 | SyncTideUseCase 実装 | [implementation_plan.md](implementation_plan.md#t-010-synctideusecase-実装) | [#21](https://github.com/nakagawah13/fishing-forecast-gcal/issues/21) | Not Started |
+| T-011 | 1.4 | 設定ファイルローダー | [implementation_plan.md](implementation_plan.md#t-011-設定ファイルローダー) | [#22](https://github.com/nakagawah13/fishing-forecast-gcal/issues/22) | Not Started |
+| T-012 | 1.4 | CLI エントリーポイント | [implementation_plan.md](implementation_plan.md#t-012-cliエントリーポイント) | [#23](https://github.com/nakagawah13/fishing-forecast-gcal/issues/23) | Not Started |
+| T-013 | 1.5 | E2E テスト | [implementation_plan.md](implementation_plan.md#t-013-e2eテスト) | [#24](https://github.com/nakagawah13/fishing-forecast-gcal/issues/24) | Not Started |
 
 ## フェーズ 2（予報更新）
 
 | Task ID | Phase | Title | Plan Link | Issue | Status |
 | --- | --- | --- | --- | --- | --- |
-| T-014 | 2 | Weather API クライアント | [implementation_plan.md](implementation_plan.md#t-014-weather-api-クライアント) | TBD | Not Started |
-| T-015 | 2 | WeatherRepository 実装 | [implementation_plan.md](implementation_plan.md#t-015-weatherrepository-実装) | TBD | Not Started |
-| T-016 | 2 | イベント本文フォーマッター | [implementation_plan.md](implementation_plan.md#t-016-イベント本文フォーマッター) | TBD | Not Started |
-| T-017 | 2 | SyncWeatherUseCase 実装 | [implementation_plan.md](implementation_plan.md#t-017-syncweatherusecase-実装) | TBD | Not Started |
-| T-018 | 2 | Scheduler 実装 | [implementation_plan.md](implementation_plan.md#t-018-scheduler-実装) | TBD | Not Started |
+| T-014 | 2 | Weather API クライアント | [implementation_plan.md](implementation_plan.md#t-014-weather-api-クライアント) | [#25](https://github.com/nakagawah13/fishing-forecast-gcal/issues/25) | Not Started |
+| T-015 | 2 | WeatherRepository 実装 | [implementation_plan.md](implementation_plan.md#t-015-weatherrepository-実装) | [#26](https://github.com/nakagawah13/fishing-forecast-gcal/issues/26) | Not Started |
+| T-016 | 2 | イベント本文フォーマッター | [implementation_plan.md](implementation_plan.md#t-016-イベント本文フォーマッター) | [#27](https://github.com/nakagawah13/fishing-forecast-gcal/issues/27) | Not Started |
+| T-017 | 2 | SyncWeatherUseCase 実装 | [implementation_plan.md](implementation_plan.md#t-017-syncweatherusecase-実装) | [#28](https://github.com/nakagawah13/fishing-forecast-gcal/issues/28) | Not Started |
+| T-018 | 2 | Scheduler 実装 | [implementation_plan.md](implementation_plan.md#t-018-scheduler-実装) | [#29](https://github.com/nakagawah13/fishing-forecast-gcal/issues/29) | Not Started |
 
 ## フェーズ 3（運用強化）
 
 | Task ID | Phase | Title | Plan Link | Issue | Status |
 | --- | --- | --- | --- | --- | --- |
-| T-019 | 3 | リトライロジック強化 | [implementation_plan.md](implementation_plan.md#t-019-リトライロジック強化) | TBD | Not Started |
-| T-020 | 3 | 監視ログ | [implementation_plan.md](implementation_plan.md#t-020-監視ログ) | TBD | Not Started |
-| T-021 | 3 | 複数地点対応 | [implementation_plan.md](implementation_plan.md#t-021-複数地点対応) | TBD | Not Started |
+| T-019 | 3 | リトライロジック強化 | [implementation_plan.md](implementation_plan.md#t-019-リトライロジック強化) | [#30](https://github.com/nakagawah13/fishing-forecast-gcal/issues/30) | Not Started |
+| T-020 | 3 | 監視ログ | [implementation_plan.md](implementation_plan.md#t-020-監視ログ) | [#31](https://github.com/nakagawah13/fishing-forecast-gcal/issues/31) | Not Started |
+| T-021 | 3 | 複数地点対応 | [implementation_plan.md](implementation_plan.md#t-021-複数地点対応) | [#32](https://github.com/nakagawah13/fishing-forecast-gcal/issues/32) | Not Started |


### PR DESCRIPTION
## 変更概要

- [task_table.md](docs/task_table.md) の全29タスクに GitHub issue 番号を追加
- フェーズ0: #4-#11（8タスク）
- フェーズ1: #12-#24（13タスク）
- フェーズ2: #25-#29（5タスク）
- フェーズ3: #30-#32（3タスク）

## 変更理由

各タスクに対応する GitHub issue を作成したため、task_table.md から直接 issue にリンクできるようにする。
これにより、タスクの追跡と管理が容易になり、Issue ドリブンの開発フローを実現する。

## タスク対応

該当なし（ドキュメント整備のため implementation_plan.md のタスクには該当しない）

## 影響範囲

- **変更ファイル**:
  - `docs/task_table.md` - 全タスクの Issue 列を TBD から issue番号へ更新

- **依存モジュール**:
  - なし（ドキュメントのみの変更）

## テスト / 検証

| 種別 | 対象 | 結果 |
|------|------|------|
| リンク確認 | 全29タスクのissueリンク | ✅ Pass（手動確認） |
| Markdown構文 | task_table.md | ✅ Pass（レンダリング確認） |

## リスク / 互換性

| 項目 | 状態 |
|------|------|
| 破壊的変更 | なし |
| 後方互換性 | 維持（ドキュメントのみの変更） |

## 関連Issue / PR

全29タスクの issue を作成:
- Phase 0: #4, #5, #6, #7, #8, #9, #10, #11
- Phase 1: #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24
- Phase 2: #25, #26, #27, #28, #29
- Phase 3: #30, #31, #32
