### PR TITLE
docs: update Phase 0 task completion status

### DIFF
--- a/docs/task_table.md
+++ b/docs/task_table.md
@@ -18,13 +18,13 @@
 | Task ID | Phase | Title | Plan Link | Issue | Status |
 | --- | --- | --- | --- | --- | --- |
 | F0-01 | 0 | 対象地点/期間/出力フォーマットの合意 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#4](https://github.com/nakagawah13/fishing-forecast-gcal/issues/4) | Not Started |
-| F0-02 | 0 | Google カレンダーのイベント設計確定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#5](https://github.com/nakagawah13/fishing-forecast-gcal/issues/5) | Not Started |
-| F0-03 | 0 | 天文潮の取得方式を決定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#6](https://github.com/nakagawah13/fishing-forecast-gcal/issues/6) | Not Started |
-| F0-04 | 0 | タイドグラフ画像の表現方針（後続検討） | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#7](https://github.com/nakagawah13/fishing-forecast-gcal/issues/7) | Not Started |
-| F0-05 | 0 | 開発環境手順（uv）をドキュメント化 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#8](https://github.com/nakagawah13/fishing-forecast-gcal/issues/8) | Not Started |
+| F0-02 | 0 | Google カレンダーのイベント設計確定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#5](https://github.com/nakagawah13/fishing-forecast-gcal/issues/5) | ✅ Completed |
+| F0-03 | 0 | 天文潮の取得方式を決定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#6](https://github.com/nakagawah13/fishing-forecast-gcal/issues/6) | ✅ Completed |
+| F0-04 | 0 | タイドグラフ画像の表現方針（後続検討） | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#7](https://github.com/nakagawah13/fishing-forecast-gcal/issues/7) | ✅ Completed |
+| F0-05 | 0 | 開発環境手順（uv）をドキュメント化 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#8](https://github.com/nakagawah13/fishing-forecast-gcal/issues/8) | ✅ Completed |
 | F0-06 | 0 | 配布/セットアップ手順の草案化 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#9](https://github.com/nakagawah13/fishing-forecast-gcal/issues/9) | Not Started |
-| F0-07 | 0 | 更新ウィンドウの範囲を決定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#10](https://github.com/nakagawah13/fishing-forecast-gcal/issues/10) | Not Started |
-| F0-08 | 0 | レイヤードアーキテクチャの詳細設計 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#11](https://github.com/nakagawah13/fishing-forecast-gcal/issues/11) | Not Started |
+| F0-07 | 0 | 更新ウィンドウの範囲を決定 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#10](https://github.com/nakagawah13/fishing-forecast-gcal/issues/10) | ✅ Completed |
+| F0-08 | 0 | レイヤードアーキテクチャの詳細設計 | [implementation_plan.md](implementation_plan.md#フェーズ-0-仕様確定短期) | [#11](https://github.com/nakagawah13/fishing-forecast-gcal/issues/11) | ✅ Completed |
 
 ## フェーズ 1（MVP）
 


### PR DESCRIPTION
## 変更概要

フェーズ0の完了済みタスクのステータスを `docs/task_table.md` に反映します。

## 更新内容

以下の6つのフェーズ0タスクを **✅ Completed** に更新:

| Task ID | Issue | タイトル | ステータス |
|---------|-------|---------|-----------|
| F0-02 | [#5](https://github.com/nakagawah13/fishing-forecast-gcal/issues/5) | Google カレンダーのイベント設計確定 | ✅ Completed |
| F0-03 | [#6](https://github.com/nakagawah13/fishing-forecast-gcal/issues/6) | 天文潮の取得方式を決定 | ✅ Completed |
| F0-04 | [#7](https://github.com/nakagawah13/fishing-forecast-gcal/issues/7) | タイドグラフ画像の表現方針 | ✅ Completed |
| F0-05 | [#8](https://github.com/nakagawah13/fishing-forecast-gcal/issues/8) | 開発環境手順（uv）をドキュメント化 | ✅ Completed |
| F0-07 | [#10](https://github.com/nakagawah13/fishing-forecast-gcal/issues/10) | 更新ウィンドウの範囲を決定 | ✅ Completed |
| F0-08 | [#11](https://github.com/nakagawah13/fishing-forecast-gcal/issues/11) | レイヤードアーキテクチャの詳細設計 | ✅ Completed |

## 背景

PR #36 のマージ後に、フェーズ0の実施済みIssueをクローズしました。各Issueには詳細な実施完了コメントを追加済みです。この変更は、それらの完了状況を `task_table.md` に反映するものです。

## 影響範囲

- **変更ファイル**: `docs/task_table.md` のみ
- **破壊的変更**: なし
- **依存関係**: なし

## リスク / 互換性

| 項目 | 状態 |
|------|------|
| 破壊的変更 | なし |
| 後方互換性 | 維持（ドキュメントのみの変更） |
| コード変更 | なし |

## 関連

- 元のPR: #36 (T-002: リポジトリインターフェース定義)
- クローズしたIssue: #5, #6, #7, #8, #10, #11

---

**注**: この変更はドキュメントのみの更新であり、コード変更は含みません。軽微な変更のため、直接マージしていただいて問題ありません。