### PR TITLE
docs: add phase 1.8 tasks (T-013.8, T-013.9)

### DIFF
--- a/docs/task_table.md
+++ b/docs/task_table.md
@@ -51,6 +51,13 @@
 | T-013.6 | 1.6 | イベントタイトルの潮回り絵文字化 ([doc](completed/issue-56.md)) | [implementation_plan.md](implementation_plan.md#t-0136-イベントタイトルの潮回り絵文字化) | [#56](https://github.com/nakagawah13/fishing-forecast-gcal/issues/56) | ✅ Completed |
 | T-013.7 | 1.7 | 釣り情報の初期化コマンド ([doc](completed/issue-58.md)) | [implementation_plan.md](implementation_plan.md#t-0137-釣り情報の初期化コマンド) | [#58](https://github.com/nakagawah13/fishing-forecast-gcal/issues/58) | ✅ Completed |
 
+## フェーズ 1.8（MVP安定化・第3弾）
+
+| Task ID | Phase | Title | Plan Link | Issue | Status |
+| --- | --- | --- | --- | --- | --- |
+| T-013.8 | 1.8 | JMA推算テキストパーサーの分離 | [implementation_plan.md](implementation_plan.md#t-0138-jma推算テキストパーサーの分離) | [#69](https://github.com/nakagawah13/fishing-forecast-gcal/issues/69) | Not Started |
+| T-013.9 | 1.8 | JMA潮汐データ取得ロジックの正式モジュール化と全70地点拡張 | [implementation_plan.md](implementation_plan.md#t-0139-jma潮汐データ取得ロジックの正式モジュール化と全70地点拡張) | [#70](https://github.com/nakagawah13/fishing-forecast-gcal/issues/70) | Not Started |
+
 ## フェーズ 2（予報更新）
 
 | Task ID | Phase | Title | Plan Link | Issue | Status |


### PR DESCRIPTION
## 変更概要

Phase 1.8（MVP安定化・第3弾）のタスク定義を2件追加

- `T-013.8`: JMA推算テキストパーサーの分離（Issue #69）
- `T-013.9`: JMA潮汐データ取得ロジックの正式モジュール化と全70地点拡張（Issue #70）

## 変更理由

Issue #69, #70 を起票したため、対応するタスク定義を実装計画書およびタスク表に追加する必要がある。

両 Issue は `scripts/` ディレクトリ内の臨時スクリプトに関する技術的負債を解消し、コード品質とテスト基盤を改善するもの。

## タスク対応

| Task ID | Epic | 状態 (Before → After) | 概要 |
|---------|------|----------------------|------|
| (新規) | Phase 1.8 | ⚪ Not Started → ⚪ Not Started | ドキュメントのみの変更 |

**更新対象ファイル**: `docs/implementation_plan.md`, `docs/task_table.md`

## 影響範囲

### 変更ファイル
- `docs/implementation_plan.md` - Phase 1.8 セクションと T-013.8, T-013.9 タスク定義を追加
- `docs/task_table.md` - Phase 1.8 テーブルと T-013.8, T-013.9 行を追加

### 依存モジュール
- なし（ドキュメントのみの変更）

### 設定変更
- なし

## テスト / 検証

| 種別 | 対象 | 結果 |
|------|------|------|
| ドキュメント整合性 | 両ファイルのタスク定義が一致 | ✅ Pass |
| Issue リンク | #69, #70 へのリンクが正しい | ✅ Pass |
| フォーマット | Markdown 表形式 | ✅ Pass |

## リスク / 互換性

| 項目 | 状態 |
|------|------|
| 破壊的変更 | なし |
| 後方互換性 | 維持 |
| API変更 | なし |
| 設定ファイル変更 | なし |

## 関連Issue / PR

- Refs #69 - JMA推算テキストパーサーの分離
- Refs #70 - JMA潮汐データ取得ロジックの正式モジュール化と全70地点拡張
