### PR TITLE
docs: mark T-014 as pending and document blocking dependencies

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -737,6 +737,17 @@
 #### T-014: Weather API クライアント
 **責務**: 気象予報APIのラッパー
 
+**ステータス**: ⏸️ Pending（API 選定待ち）
+
+**Pending 理由**（2026-02-11）:
+- Issue #25 で指定の tsukumijima API を実測調査した結果、風速 (m/s) と気圧 (hPa) の数値データが提供されないことが判明
+- 現行 `FishingCondition` モデル（`wind_speed_mps: float`, `pressure_hpa: float` を必須）と不整合
+- 代替候補として Open-Meteo API（無料、風速・気圧・気温を数値提供、日本対応）を調査済み
+- API 選定の決定後に実装を再開する
+- 詳細: Issue #25 コメント参照
+
+**ブロック影響**: T-015, T-017, T-018, T-019（一部）が本タスクに依存
+
 **成果物**:
 - `infrastructure/clients/weather_api_client.py`
   - 予報データ取得

--- a/docs/task_table.md
+++ b/docs/task_table.md
@@ -63,11 +63,11 @@
 
 | Task ID | Phase | Title | Plan Link | Issue | Status |
 | --- | --- | --- | --- | --- | --- |
-| T-014 | 2 | Weather API クライアント | [implementation_plan.md](implementation_plan.md#t-014-weather-api-クライアント) | [#25](https://github.com/nakagawah13/fishing-forecast-gcal/issues/25) | Not Started |
-| T-015 | 2 | WeatherRepository 実装 | [implementation_plan.md](implementation_plan.md#t-015-weatherrepository-実装) | [#26](https://github.com/nakagawah13/fishing-forecast-gcal/issues/26) | Not Started |
+| T-014 | 2 | Weather API クライアント | [implementation_plan.md](implementation_plan.md#t-014-weather-api-クライアント) | [#25](https://github.com/nakagawah13/fishing-forecast-gcal/issues/25) | ⏸️ Pending (API選定待ち) |
+| T-015 | 2 | WeatherRepository 実装 | [implementation_plan.md](implementation_plan.md#t-015-weatherrepository-実装) | [#26](https://github.com/nakagawah13/fishing-forecast-gcal/issues/26) | ⏸️ Blocked by T-014 |
 | T-016 | 2 | イベント本文フォーマッター | [implementation_plan.md](implementation_plan.md#t-016-イベント本文フォーマッター) | [#27](https://github.com/nakagawah13/fishing-forecast-gcal/issues/27) | Not Started |
-| T-017 | 2 | SyncWeatherUseCase 実装 | [implementation_plan.md](implementation_plan.md#t-017-syncweatherusecase-実装) | [#28](https://github.com/nakagawah13/fishing-forecast-gcal/issues/28) | Not Started |
-| T-018 | 2 | Scheduler 実装 | [implementation_plan.md](implementation_plan.md#t-018-scheduler-実装) | [#29](https://github.com/nakagawah13/fishing-forecast-gcal/issues/29) | Not Started |
+| T-017 | 2 | SyncWeatherUseCase 実装 | [implementation_plan.md](implementation_plan.md#t-017-syncweatherusecase-実装) | [#28](https://github.com/nakagawah13/fishing-forecast-gcal/issues/28) | ⏸️ Blocked by T-014 |
+| T-018 | 2 | Scheduler 実装 | [implementation_plan.md](implementation_plan.md#t-018-scheduler-実装) | [#29](https://github.com/nakagawah13/fishing-forecast-gcal/issues/29) | ⏸️ Blocked by T-014 |
 
 ## フェーズ 3（運用強化）
 


### PR DESCRIPTION
## 変更概要

- T-014 (Weather API Client) のステータスを `Pending` に変更
- tsukumijima API の実測調査結果を Issue #25 にコメントとして記録
- ブロックされるタスク (T-015, T-017, T-018) のステータスを `Blocked by T-014` に更新
- `implementation_plan.md` に Pending 理由とブロック影響を追記
- `task_table.md` のフェーズ 2 タスク状態を同期

## 変更理由

Issue #25 で指定の tsukumijima API を実測調査した結果、以下の不整合が判明:

- tsukumijima API は風速 (m/s) と気圧 (hPa) の数値データを提供しない
- 風情報はテキストのみ（例: 「北の風　やや強く」）
- 現行 `FishingCondition` モデル（`wind_speed_mps: float`, `pressure_hpa: float` を必須）と不適合
- 代替候補として Open-Meteo API を調査済み（無料、全数値データ提供、日本対応）

API 選定の決定が必要なため、関連タスクのステータスを更新し、ブロック関係を明示化する。

## タスク対応

| Task ID | Epic | 状態 (Before → After) | 概要 |
|---------|------|----------------------|------|
| T-014 | 予報更新 | ⚪ Not Started → ⏸️ Pending | API 選定待ち |
| T-015 | 予報更新 | ⚪ Not Started → ⏸️ Blocked | T-014 に依存 |
| T-016 | 予報更新 | ⚪ Not Started → ⚪ Not Started | 変更なし（ブロックなし） |
| T-017 | 予報更新 | ⚪ Not Started → ⏸️ Blocked | T-015 経由で T-014 に依存 |
| T-018 | 予報更新 | ⚪ Not Started → ⏸️ Blocked | T-017 経由で T-014 に依存 |

**更新対象ファイル**: `docs/implementation_plan.md`, `docs/task_table.md`

## 影響範囲

- **変更ファイル**:
  - `docs/implementation_plan.md` - T-014 に Pending ステータスと理由を追記
  - `docs/task_table.md` - フェーズ 2 タスクのステータス列を更新

- **GitHub Issue 更新** (PR外の変更):
  - Issue #25: 調査結果コメント追加
  - Issue #26: Blocked by #25 コメント追加
  - Issue #28: Blocked by #25 (via #26) コメント追加
  - Issue #29: Blocked by #25 (via #26, #28) コメント追加
  - Issue #30: Partially Blocked by #25 コメント追加

## テスト / 検証

| 種別 | 対象 | 結果 |
|------|------|------|
| ドキュメント整合性 | implementation_plan.md / task_table.md | ✅ Pass |
| Issue 同期 | GitHub Issues #25, #26, #28, #29, #30 | ✅ Pass |
| コード変更 | なし | N/A |
| テスト実行 | なし（ドキュメントのみ変更） | N/A |

## リスク / 互換性

| 項目 | 状態 |
|------|------|
| 破壊的変更 | なし |
| 後方互換性 | 維持 |
| API 変更 | なし |
| 設定ファイル変更 | なし |

## ブロック関係マップ

```
T-014 (⏸️ Pending: API選定待ち)
  ├── T-015 (⏸️ Blocked)
  │     └── T-017 (⏸️ Blocked)
  │           ├── T-018 (⏸️ Blocked)
  │           └── T-019 (⏸️ Partially Blocked)
  └── (T-016 はブロックなし: T-001 のみ依存)
```

**着手可能なタスク**: T-016 (#27), #63 (bug fix), #9 (F0-06), #4 (F0-01)

## 関連Issue / PR

- Refs #25 - T-014: Weather API クライアント（Pending）
- Refs #26 - T-015: WeatherRepository 実装（Blocked）
- Refs #28 - T-017: SyncWeatherUseCase 実装（Blocked）
- Refs #29 - T-018: Scheduler 実装（Blocked）
- Refs #30 - T-019: リトライロジック強化（Partially Blocked）
