### PR TITLE
docs: add T-013.17 prime time multiple high tides task

### DIFF
--- a/docs/task_table.md
+++ b/docs/task_table.md
@@ -79,6 +79,12 @@
 | T-013.15 | 1.10 | TideDataRepository の DI 改善 ([doc](completed/issue-93.md)) | [implementation_plan.md](implementation_plan.md#t-01315-tidedatarepository-のドメインロジック分離と-di-改善-) | [#93](https://github.com/nakagawah13/fishing-forecast-gcal/issues/93) | ✅ Completed |
 | T-013.16 | 1.10 | OAuth スコープ不一致時の再認証ハンドリング ([doc](completed/issue-98.md)) | [implementation_plan.md](implementation_plan.md#t-01316-oauth-スコープ不一致時の再認証ハンドリング) | [#98](https://github.com/nakagawah13/fishing-forecast-gcal/issues/98) | ✅ Completed |
 
+## フェーズ 1.11（バグ修正）
+
+| Task ID | Phase | Title | Plan Link | Issue | Status |
+| --- | --- | --- | --- | --- | --- |
+| T-013.17 | 1.11 | 時合い帯の複数満潮対応 | [implementation_plan.md](implementation_plan.md#t-01317-時合い帯の複数満潮対応1日2回の時合い計算) | [#101](https://github.com/nakagawah13/fishing-forecast-gcal/issues/101) | Not Started |
+
 ## フェーズ 2（予報更新）
 
 | Task ID | Phase | Title | Plan Link | Issue | Status |


### PR DESCRIPTION
## 変更概要

- `implementation_plan.md` にフェーズ 1.11（バグ修正）セクションと T-013.17 タスク定義を追加
- `task_table.md` にフェーズ 1.11 テーブルと T-013.17 行を追加
- Issue #101（時合い帯が1日1回しか計算されないバグ）に対応するタスクを登録

## 変更理由

時合い（prime time）は満潮の前後 ±2 時間と定義されており、1日に2回訪れる満潮それぞれに対して計算されるべきである。
現行実装では `PrimeTimeFinder.find()` が最初の満潮 (`high_tides[0]`) のみを基準に時合いを計算しており、2回目の満潮に対する時合いが欠落している。

バグ修正の実装に先立ち、タスク定義とドキュメントへの反映を行う。

関連 Issue: #101

## タスク対応

| Task ID | Epic | 状態 (Before → After) | 概要 |
|---------|------|----------------------|------|
| T-013.17 | バグ修正 | N/A → ⚪ Not Started | 時合い帯の複数満潮対応（タスク登録） |

**更新対象ファイル**: `docs/implementation_plan.md`, `docs/task_table.md`

## 影響範囲

- **変更ファイル**:
  - `docs/implementation_plan.md` - フェーズ 1.11 セクション追加（T-013.17 タスク定義）
  - `docs/task_table.md` - フェーズ 1.11 テーブル追加（T-013.17 行）

- **依存モジュール**: なし（ドキュメントのみの変更）

- **設定変更**: なし

## テスト / 検証

| 種別 | 対象 | 結果 |
|------|------|------|
| ユニットテスト | 全テスト (448件) | ✅ Pass |
| Lint | `ruff check .` | ✅ Pass |
| フォーマット | `ruff format --check .` | ✅ Pass |

## リスク / 互換性

| 項目 | 状態 |
|------|------|
| 破壊的変更 | なし |
| 後方互換性 | 維持 |
| API 変更 | なし |
| 設定ファイル変更 | なし |

## 関連 Issue / PR

- Refs #101 - 時合い帯が1日1回しか計算されないバグ
