### PR TITLE
fix(drive): add idempotent upload to prevent duplicate tide graph images

### DIFF
--- a/docs/completed/issue-104.md
+++ b/docs/completed/issue-104.md
@@ -1,6 +1,6 @@
 # Issue #104: sync-tide の複数回実行で Google Drive にタイドグラフ画像が重複保存される
 
-## ステータス: In Progress
+## ステータス: Completed
 
 ## 概要
 
@@ -59,3 +59,24 @@
 2. **ユニットテスト**: UseCase 側で新メソッドが呼ばれることの確認
 3. **ruff / pyright**: 静的解析パス
 4. **手動テスト**: `sync-tide` の複数回実行で Drive 上に重複が発生しないことを確認
+
+## 実装結果・変更点
+
+### 実施内容
+
+- `GoogleDriveClient` に `upload_or_update_file()` メソッドを追加
+  - フォルダ内で同名ファイルを `files().list()` で検索
+  - 存在すれば `files().update()` で上書き更新（権限設定は既存を維持）
+  - 存在しなければ `files().create()` で新規作成＋公開読み取り権限を設定
+- `SyncTideUseCase._generate_and_upload_graph()` の呼び出しを `upload_file()` → `upload_or_update_file()` に変更
+- ユニットテスト 5 件を追加（新規作成、既存更新、ファイル未存在エラー、folder_id なし、URL フォーマット確認）
+- テストモック 3 箇所を `upload_or_update_file` に更新
+
+### テスト結果
+
+| 種別 | 対象 | 結果 |
+|------|------|------|
+| ユニットテスト | 452 件 | ✅ Pass |
+| Lint | ruff check | ✅ Pass |
+| フォーマット | ruff format | ✅ Pass |
+| 型チェック | pyright | ✅ Pass |

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -921,6 +921,32 @@
 **依存**: T-005, T-010
 **Issue**: [#101](https://github.com/nakagawah13/fishing-forecast-gcal/issues/101)
 
+#### T-013.18: Drive 画像の冪等アップロード（重複防止）
+**責務**: `sync-tide` 複数回実行時に Google Drive 上のタイドグラフ画像が重複保存される問題を修正
+
+**ステータス**: ✅ 完了
+
+**背景**:
+- `GoogleDriveClient.upload_file()` が `files().create()` で常に新規ファイルを作成していた
+- Google Drive は同名ファイルの共存を許容するため、実行ごとに重複が増殖
+- カレンダーイベント側は `upsert_event` で冪等性を担保済みだが、Drive 側は未対応だった
+
+**変更内容**:
+- `GoogleDriveClient` に `upload_or_update_file()` メソッドを追加
+  - フォルダ内で同名ファイルを検索し、存在すれば `files().update()` で上書き
+  - 存在しなければ従来通り `files().create()` で新規作成
+- `SyncTideUseCase._generate_and_upload_graph()` の呼び出しを変更
+
+**テスト要件**:
+- 同名ファイルありの場合に update が呼ばれること ✅
+- 同名ファイルなしの場合に create が呼ばれること ✅
+- UseCase 側で新メソッドが呼ばれることの確認 ✅
+
+**依存**: T-013.11c
+**Issue**: [#104](https://github.com/nakagawah13/fishing-forecast-gcal/issues/104)
+
+---
+
 ## フェーズ 2: 直前更新（予報）
 
 ### タスク分割

--- a/docs/inprogress/issue-104.md
+++ b/docs/inprogress/issue-104.md
@@ -1,0 +1,61 @@
+# Issue #104: sync-tide の複数回実行で Google Drive にタイドグラフ画像が重複保存される
+
+## ステータス: In Progress
+
+## 概要
+
+`sync-tide` コマンドを複数回実行すると、Google Drive 上に同名のタイドグラフ画像
+が重複して保存される。カレンダーイベント側は `upsert_event` で冪等性を担保して
+いるが、Drive アップロード側には同名ファイルの存在チェックがなく、実行ごとに
+新規ファイルが作成される。
+
+## 原因分析
+
+### `GoogleDriveClient.upload_file()`
+
+- `service.files().create()` で常に新規ファイルを作成
+- Google Drive は同名ファイルの共存を許容するため、呼び出しのたびに重複
+
+### `SyncTideUseCase._generate_and_upload_graph()`
+
+- `upload_file()` を無条件に呼び出し
+- 既存画像の確認や置換ロジックなし
+
+## 修正方針
+
+**案 A（推奨: update 方式）** を採用する。
+
+### 実装内容
+
+#### 1. `GoogleDriveClient` に `upload_or_update_file()` メソッドを追加
+
+- フォルダ内で同名ファイルを `list_files()` で検索
+- 存在すれば `service.files().update()` で上書き（メディアのみ更新）
+- 存在しなければ従来通り `service.files().create()` で新規作成
+- いずれの場合も公開読み取り権限を設定
+
+#### 2. `SyncTideUseCase._generate_and_upload_graph()` を修正
+
+- `upload_file()` → `upload_or_update_file()` に変更
+
+### メリット
+
+- ファイル ID が維持される → Calendar attachments の URL が変わらない
+- 既存の `list_files()` を活用でき、最小限の変更で済む
+- 冪等性が担保される
+
+## 変更予定ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/.../infrastructure/clients/google_drive_client.py` | `upload_or_update_file()` メソッド追加 |
+| `src/.../application/usecases/sync_tide_usecase.py` | `upload_file()` → `upload_or_update_file()` 呼び出し変更 |
+| `tests/.../clients/test_google_drive_client.py` | `upload_or_update_file()` のテスト追加 |
+| `tests/.../usecases/test_sync_tide_usecase.py` | `upload_or_update_file()` を使用するテスト修正 |
+
+## 検証計画
+
+1. **ユニットテスト**: `upload_or_update_file()` の新規作成パス・更新パスの分岐テスト
+2. **ユニットテスト**: UseCase 側で新メソッドが呼ばれることの確認
+3. **ruff / pyright**: 静的解析パス
+4. **手動テスト**: `sync-tide` の複数回実行で Drive 上に重複が発生しないことを確認

--- a/docs/task_table.md
+++ b/docs/task_table.md
@@ -83,8 +83,7 @@
 
 | Task ID | Phase | Title | Plan Link | Issue | Status |
 | --- | --- | --- | --- | --- | --- |
-| T-013.17 | 1.11 | 時合い帯の複数満潮対応 | [implementation_plan.md](implementation_plan.md#t-01317-時合い帯の複数満潮対応1日2回の時合い計算) | [#101](https://github.com/nakagawah13/fishing-forecast-gcal/issues/101) | Not Started |
-
+| T-013.17 | 1.11 | 時合い帯の複数満潮対応 | [implementation_plan.md](implementation_plan.md#t-01317-時合い帯の複数満潮対応1日2回の時合い計算) | [#101](https://github.com/nakagawah13/fishing-forecast-gcal/issues/101) | Not Started || T-013.18 | 1.11 | Drive 画像の冪等アップロード ([doc](completed/issue-104.md)) | [implementation_plan.md](implementation_plan.md#t-01318-drive-画像の冪等アップロード重複防止) | [#104](https://github.com/nakagawah13/fishing-forecast-gcal/issues/104) | ✅ Completed |
 ## フェーズ 2（予報更新）
 
 | Task ID | Phase | Title | Plan Link | Issue | Status |

--- a/src/fishing_forecast_gcal/application/usecases/sync_tide_usecase.py
+++ b/src/fishing_forecast_gcal/application/usecases/sync_tide_usecase.py
@@ -197,8 +197,8 @@ class SyncTideUseCase:
             # 4. Drive フォルダを取得/作成
             folder_id = self._drive_client.get_or_create_folder(self._drive_folder_name)
 
-            # 5. Drive にアップロード
-            upload_result = self._drive_client.upload_file(
+            # 5. Drive にアップロード（同名ファイルがあれば上書き更新）
+            upload_result = self._drive_client.upload_or_update_file(
                 file_path=image_path,
                 mime_type="image/png",
                 folder_id=folder_id,

--- a/tests/unit/application/usecases/test_sync_tide_usecase.py
+++ b/tests/unit/application/usecases/test_sync_tide_usecase.py
@@ -644,7 +644,7 @@ class TestSyncTideUseCaseTideGraph:
         """MockのGoogleDriveクライアント"""
         client = Mock()
         client.get_or_create_folder.return_value = "folder-id-123"
-        client.upload_file.return_value = {
+        client.upload_or_update_file.return_value = {
             "file_id": "file-id-456",
             "file_url": "https://drive.google.com/file/d/file-id-456/view?usp=drivesdk",
         }
@@ -682,9 +682,9 @@ class TestSyncTideUseCaseTideGraph:
         # hourly_heights が取得された
         mock_tide_repo.get_hourly_heights.assert_called_once_with(location, target_date)
 
-        # Drive にアップロードされた
+        # Drive にアップロードされた（冪等アップロード）
         mock_drive_client.get_or_create_folder.assert_called_once_with("test-folder")
-        mock_drive_client.upload_file.assert_called_once()
+        mock_drive_client.upload_or_update_file.assert_called_once()
 
         # upsert_event に attachments が渡された
         call_kwargs = mock_calendar_repo.upsert_event.call_args[1]
@@ -753,7 +753,7 @@ class TestSyncTideUseCaseTideGraph:
         """Driveアップロードが失敗しても、attachments なしでイベント登録は継続される"""
         mock_drive = Mock()
         mock_drive.get_or_create_folder.return_value = "folder-id"
-        mock_drive.upload_file.side_effect = RuntimeError("Network error")
+        mock_drive.upload_or_update_file.side_effect = RuntimeError("Network error")
 
         usecase = SyncTideUseCase(
             tide_repo=mock_tide_repo,


### PR DESCRIPTION
## 変更概要

- `GoogleDriveClient` に `upload_or_update_file()` メソッドを追加（同名ファイルが存在すれば上書き更新、なければ新規作成）
- `SyncTideUseCase._generate_and_upload_graph()` の呼び出しを `upload_file()` → `upload_or_update_file()` に変更
- ユニットテスト 5 件を追加（新規作成パス、更新パス、エラー、folder_id なし、URL フォーマット）
- 既存テストモック 3 箇所を `upload_or_update_file` に更新
- T-013.18 として `implementation_plan.md` と `task_table.md` に追加

## 変更理由

`sync-tide` コマンドを複数回実行すると、Google Drive 上に同名のタイドグラフ画像が重複保存される問題が発生していた。カレンダーイベント側は `upsert_event` で冪等性を担保済みだが、Drive 側には同名ファイルの存在チェックがなく、実行ごとに新規ファイルが増殖する状態だった。

## タスク対応

| Task ID | Epic | 状態 (Before → After) | 概要 |
|---------|------|----------------------|------|
| T-013.18 | バグ修正 | ⚪ Not Started → ✅ Done | Drive 画像の冪等アップロード |

**更新対象ファイル**: `docs/implementation_plan.md`, `docs/task_table.md`

## 影響範囲

- **変更ファイル**:
  - `src/.../infrastructure/clients/google_drive_client.py` - `upload_or_update_file()` メソッド追加
  - `src/.../application/usecases/sync_tide_usecase.py` - 呼び出しメソッド変更
  - `tests/.../clients/test_google_drive_client.py` - テスト 5 件追加
  - `tests/.../usecases/test_sync_tide_usecase.py` - モック名変更 3 箇所

- **依存モジュール**:
  - `presentation/commands/sync_tide.py` - UseCase を呼び出す側（変更なし）

## テスト / 検証

| 種別 | 対象 | 結果 |
|------|------|------|
| ユニットテスト | 452 件 | ✅ Pass |
| Lint | ruff check | ✅ Pass |
| フォーマット | ruff format | ✅ Pass |
| 型チェック | pyright | ✅ Pass |

## リスク / 互換性

| 項目 | 状態 |
|------|------|
| 破壊的変更 | なし |
| 後方互換性 | 維持（既存の `upload_file()` は変更なし） |
| API 変更 | 新規メソッド追加のみ |

## 関連Issue / PR

- Closes #104 - sync-tide の複数回実行で Google Drive にタイドグラフ画像が重複保存される
